### PR TITLE
Fixed some errors for compatibility with Phonegap 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Using this plugin requires [Cordova Android](https://github.com/apache/incubator
         // if successful status is an object that looks like this:
         // {"type":"7","pushBadge":"1","pushSound":"1","enabled":"1","deviceToken":"blablahblah","pushAlert":"1"}
         console.warn('registerDevice:%o', status);
-        navigator.notification.alert(JSON.stringify(event.notification.aps.alert));
+        navigator.notification.alert(JSON.stringify(['registerDevice', status]));
     });
 
 
@@ -182,7 +182,7 @@ Finally, when a remote push notification is received while the application is ac
 
     document.addEventListener('push-notification', function(event) {
         console.warn('push-notification!:%o', event);
-        navigator.notification.alert(JSON.stringify(['push-notification!', event]));
+        navigator.notification.alert(JSON.stringify(event.notification.aps.alert));
     });
 
 * Check [source](https://github.com/mgcrea/cordova-push-notification/tree/master/www/PushNotification.js) for additional configuration.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Using this plugin requires [Cordova Android](https://github.com/apache/incubator
         // if successful status is an object that looks like this:
         // {"type":"7","pushBadge":"1","pushSound":"1","enabled":"1","deviceToken":"blablahblah","pushAlert":"1"}
         console.warn('registerDevice:%o', status);
-        navigator.notification.alert(JSON.stringify(['registerDevice', status]));
+        navigator.notification.alert(JSON.stringify(event.notification.aps.alert));
     });
 
 

--- a/src/ios/PushNotification.m
+++ b/src/ios/PushNotification.m
@@ -8,7 +8,7 @@
 // MIT Licensed
 
 #import "PushNotification.h"
-#import <Cordova/JSONKit.h>
+#import <Cordova/CDVJSON.h>
 #import <Cordova/CDVDebug.h>
 
 @implementation PushNotification
@@ -82,7 +82,7 @@
 - (void)didReceiveRemoteNotification:(NSDictionary*)userInfo {
 	DLog(@"didReceiveRemoteNotification:%@", userInfo);
 
-	NSString *jsStatement = [NSString stringWithFormat:@"window.plugins.pushNotification.notificationCallback(%@);", [userInfo cdvjk_JSONString]];
+	NSString *jsStatement = [NSString stringWithFormat:@"window.plugins.pushNotification.notificationCallback(%@);", [userInfo JSONString]];
 	[self writeJavascript:jsStatement];
 }
 


### PR DESCRIPTION
During the development of an application with PhoneGap 2.5 i tried to get the Push Plugin to work but it crashed the app. I fixed there errors in this Pull Requests but it probably will break compatibility with earlier versions of PhoneGap. So i guess if you think the changes are correct(they worked for me), you should make this the new master and push the former code into a branch or tag so people see that this only works for new versions.
